### PR TITLE
Fix: error propagation through microservices

### DIFF
--- a/employee-service/pom.xml
+++ b/employee-service/pom.xml
@@ -18,14 +18,18 @@
 		<spring-cloud.version>2022.0.4</spring-cloud.version>
 	</properties>
 	<dependencies>
+        <!-- MongoDB -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+
+        <!-- Eureka -->
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
@@ -35,6 +39,8 @@
 			<artifactId>snakeyaml</artifactId>
 			<version>2.0</version>
 		</dependency>
+
+        <!-- Spring validation API / Jakarta validation API -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
@@ -43,6 +49,7 @@
 			<groupId>jakarta.validation</groupId>
 			<artifactId>jakarta.validation-api</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
@@ -53,14 +60,20 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+        <!-- FeignClient -->
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
 		</dependency>
+
+        <!-- Actuator -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
+
+        <!-- Config Server -->
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
@@ -93,7 +106,19 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-aop</artifactId>
 		</dependency>
-	</dependencies>
+
+		<!-- JSON Serializer and Deserializer / JSON DateType to support new Java 8 Date API-->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.15.2</version>
+		</dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.15.2</version>
+        </dependency>
+    </dependencies>
 
 	<dependencyManagement>
 		<dependencies>

--- a/employee-service/src/main/java/org/rrhh/department/application/implementation/DepartmentGetByCodeImpl.java
+++ b/employee-service/src/main/java/org/rrhh/department/application/implementation/DepartmentGetByCodeImpl.java
@@ -2,7 +2,6 @@ package org.rrhh.department.application.implementation;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import org.rrhh.department.application.usecase.DepartmentGetByCodeUseCase;
-import org.rrhh.department.domain.DepartmentConstants;
 import org.rrhh.department.domain.document.Department;
 import org.rrhh.department.domain.repository.DepartmentRepository;
 import org.slf4j.Logger;
@@ -19,15 +18,25 @@ public class DepartmentGetByCodeImpl implements DepartmentGetByCodeUseCase {
         this.departmentRepository = departmentRepository;
     }
 
+    /*
+    To use the Retry pattern, uncomment the @Retry that allows to call the external microservice
+    a certain numbers of times before it ends up in the fallback method.
+
+    @Retry(name = "${spring.application.name}", fallbackMethod = DepartmentConstants.METHOD_NAME)
+    */
     @Override
-    //@Retry(name = "${spring.application.name}", fallbackMethod = DepartmentConstants.METHOD_NAME)
-    @CircuitBreaker(name = "${spring.application.name}", fallbackMethod = DepartmentConstants.METHOD_NAME)
+    @CircuitBreaker(name = "${spring.application.name}")
     public Department getDepartmentByCode(String code) {
         LOGGER.info("#####----- inside getDepartmentByCode() method -----#####");
 
         return departmentRepository.findByCode(code);
     }
 
+    /*
+    To use the below method, add the following code inside the parentheses of @CircuitBreaker or @Retry annotation.
+    Use a comma to separate from other specifications:
+    fallbackMethod = DepartmentConstants.METHOD_NAME
+    */
     public Department getDefaultDepartment(String code, Exception exception) {
         LOGGER.error("#####----- inside getDefaultDepartment() method -----#####");
         LOGGER.error(exception.getLocalizedMessage());

--- a/employee-service/src/main/java/org/rrhh/department/infrastructure/repository/DepartmentAPIClient.java
+++ b/employee-service/src/main/java/org/rrhh/department/infrastructure/repository/DepartmentAPIClient.java
@@ -2,13 +2,15 @@ package org.rrhh.department.infrastructure.repository;
 
 import org.rrhh.department.domain.DepartmentConstants;
 import org.rrhh.department.infrastructure.dto.DepartmentResponseDTO;
+import org.rrhh.employee.infrastructure.config.FeignClientConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = DepartmentConstants.MICROSERVICE_EUREKA_CLIENT_ID)
+@FeignClient(name = DepartmentConstants.MICROSERVICE_EUREKA_CLIENT_ID, configuration = FeignClientConfiguration.class)
 public interface DepartmentAPIClient {
 
     @GetMapping(value = DepartmentConstants.GET_BY_CODE_URI)
-    DepartmentResponseDTO getDepartmentByCode(@PathVariable String departmentCode);
+    ResponseEntity<DepartmentResponseDTO> getDepartmentByCode(@PathVariable String departmentCode);
 }

--- a/employee-service/src/main/java/org/rrhh/department/infrastructure/repository/DepartmentRepositoryImpl.java
+++ b/employee-service/src/main/java/org/rrhh/department/infrastructure/repository/DepartmentRepositoryImpl.java
@@ -5,6 +5,7 @@ import org.rrhh.department.domain.document.Department;
 import org.rrhh.department.domain.repository.DepartmentRepository;
 import org.rrhh.department.infrastructure.dto.DepartmentResponseDTO;
 import org.rrhh.department.infrastructure.mapper.DepartmentMapper;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,7 +17,7 @@ public class DepartmentRepositoryImpl implements DepartmentRepository {
 
     @Override
     public Department findByCode(String code) {
-        DepartmentResponseDTO departmentResponseDTO = departmentAPIClient.getDepartmentByCode(code);
-        return departmentMapper.toDomain(departmentResponseDTO);
+        ResponseEntity<DepartmentResponseDTO> response = departmentAPIClient.getDepartmentByCode(code);
+        return departmentMapper.toDomain(response.getBody());
     }
 }

--- a/employee-service/src/main/java/org/rrhh/employee/infrastructure/config/FeignClientConfiguration.java
+++ b/employee-service/src/main/java/org/rrhh/employee/infrastructure/config/FeignClientConfiguration.java
@@ -1,11 +1,18 @@
 package org.rrhh.employee.infrastructure.config;
 
+import feign.Logger;
 import org.rrhh.department.domain.DepartmentConstants;
 import org.rrhh.organization.domain.OrganizationConstants;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableFeignClients(value = {DepartmentConstants.PACKAGE, OrganizationConstants.PACKAGE})
 public class FeignClientConfiguration {
+
+    @Bean
+    Logger.Level feignLoggerLevel() {
+        return Logger.Level.FULL;
+    }
 }

--- a/employee-service/src/main/java/org/rrhh/organization/application/implementation/OrganizationGetByCodeImpl.java
+++ b/employee-service/src/main/java/org/rrhh/organization/application/implementation/OrganizationGetByCodeImpl.java
@@ -2,7 +2,6 @@ package org.rrhh.organization.application.implementation;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import org.rrhh.organization.application.usecase.OrganizationGetByCodeUseCase;
-import org.rrhh.organization.domain.OrganizationConstants;
 import org.rrhh.organization.domain.document.Organization;
 import org.rrhh.organization.domain.repository.OrganizationRepository;
 import org.slf4j.Logger;
@@ -22,15 +21,25 @@ public class OrganizationGetByCodeImpl implements OrganizationGetByCodeUseCase {
         this.organizationRepository = organizationRepository;
     }
 
+    /*
+    To use the Retry pattern, uncomment the @Retry that allows to call the external microservice
+    a certain numbers of times before it ends up in the fallback method.
+
+    @Retry(name = "${spring.application.name}", fallbackMethod = OrganizationConstants.METHOD_NAME)
+    */
     @Override
-//    @Retry(name = "${spring.application.name}", fallbackMethod = OrganizationConstants.METHOD_NAME)
-    @CircuitBreaker(name = "${spring.application.name}", fallbackMethod = OrganizationConstants.METHOD_NAME)
+    @CircuitBreaker(name = "${spring.application.name}")
     public Organization getOrganizationByCode(String code) {
         LOGGER.info("#####----- inside getOrganizationByCode() method -----#####");
 
         return organizationRepository.findByCode(code);
     }
 
+    /*
+    To use the below method, add the following code inside the parentheses of @CircuitBreaker or @Retry annotation.
+    Use a comma to separate from other specifications:
+    fallbackMethod = DepartmentConstants.METHOD_NAME
+    */
     public Organization getDefaultOrganization(String code, Exception exception) {
         LOGGER.error("#####----- inside getDefaultOrganization() method -----#####");
         LOGGER.error(exception.getLocalizedMessage());

--- a/employee-service/src/main/java/org/rrhh/organization/infrastructure/repository/OrganizationAPIClient.java
+++ b/employee-service/src/main/java/org/rrhh/organization/infrastructure/repository/OrganizationAPIClient.java
@@ -1,14 +1,16 @@
 package org.rrhh.organization.infrastructure.repository;
 
+import org.rrhh.employee.infrastructure.config.FeignClientConfiguration;
 import org.rrhh.organization.domain.OrganizationConstants;
 import org.rrhh.organization.infrastructure.dto.OrganizationResponseDTO;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = OrganizationConstants.MICROSERVICE_EUREKA_CLIENT_ID)
+@FeignClient(name = OrganizationConstants.MICROSERVICE_EUREKA_CLIENT_ID, configuration = FeignClientConfiguration.class)
 public interface OrganizationAPIClient {
 
     @GetMapping(value = OrganizationConstants.GET_BY_CODE_URI)
-    OrganizationResponseDTO getOrganizationByCode(@PathVariable String organizationCode);
+    ResponseEntity<OrganizationResponseDTO> getOrganizationByCode(@PathVariable String organizationCode);
 }

--- a/employee-service/src/main/java/org/rrhh/organization/infrastructure/repository/OrganizationRepositoryImpl.java
+++ b/employee-service/src/main/java/org/rrhh/organization/infrastructure/repository/OrganizationRepositoryImpl.java
@@ -5,6 +5,7 @@ import org.rrhh.organization.domain.document.Organization;
 import org.rrhh.organization.domain.repository.OrganizationRepository;
 import org.rrhh.organization.infrastructure.dto.OrganizationResponseDTO;
 import org.rrhh.organization.infrastructure.mapper.OrganizationMapper;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,7 +17,7 @@ public class OrganizationRepositoryImpl implements OrganizationRepository {
 
     @Override
     public Organization findByCode(String code) {
-        OrganizationResponseDTO organizationResponseDTO = organizationAPIClient.getOrganizationByCode(code);
-        return organizationMapper.toDomain(organizationResponseDTO);
+        ResponseEntity<OrganizationResponseDTO> response = organizationAPIClient.getOrganizationByCode(code);
+        return organizationMapper.toDomain(response.getBody());
     }
 }

--- a/employee-service/src/main/resources/application.properties
+++ b/employee-service/src/main/resources/application.properties
@@ -1,2 +1,5 @@
 spring.application.name=EMPLOYEE-SERVICE
 spring.config.import=optional:configserver:http://localhost:8888
+
+logging.level.org.rrhh.department.infrastructure.repository.DepartmentAPIClient=DEBUG
+logging.level.org.rrhh.organization.infrastructure.repository.OrganizationAPIClient=DEBUG


### PR DESCRIPTION
Errors from department-service and organization-service are propagated through employee-service.
Detailed comments to enable or disable @Retry pattern and fallback method if the call to department or organization services doesn't work.
Logs for Feign in employee-service requests are visible as DEBUG level in the console.
Comments improved for dependencies in pom.xml